### PR TITLE
ZENREACH-28119: read LOGENTRIES_ENDPOINT env variable for TLS connection

### DIFF
--- a/le.go
+++ b/le.go
@@ -72,7 +72,12 @@ func (logger *Logger) Close() error {
 
 // Opens a TCP connection to logentries.com
 func openConnection() (net.Conn, error) {
-	conn, err := tls.Dial("tcp", "data.logentries.com:443", &tls.Config{})
+	endpoint := os.Getenv("LOGENTRIES_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "data.logentries.com"
+	}
+
+	conn, err := tls.Dial("tcp", endpoint + ":443", &tls.Config{})
 	return conn, err
 }
 

--- a/le_test.go
+++ b/le_test.go
@@ -3,12 +3,28 @@ package le_go
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 )
 
 func TestConnectOpensConnection(t *testing.T) {
 	le, err := Connect("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer le.Close()
+
+	if le.conn == nil {
+		t.Fail()
+	}
+}
+
+func TestEndpointEnvironmentVariableConnects(t *testing.T) {
+	os.Setenv("LOGENTRIES_ENDPOINT", "data.logentries.com")
+	le, err := Connect("")
+	os.Unsetenv("LOGENTRIES_ENDPOINT")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
https://zenreach.atlassian.net/browse/ZENREACH-28119